### PR TITLE
manifest: Properly returned requests object

### DIFF
--- a/lib/response_mate/manifest.rb
+++ b/lib/response_mate/manifest.rb
@@ -26,6 +26,8 @@ class ResponseMate::Manifest
     requests.select! do |r|
       keys.include? r.key
     end
+
+    requests
   end
 
   private

--- a/spec/lib/response_mate/manifest_spec.rb
+++ b/spec/lib/response_mate/manifest_spec.rb
@@ -160,8 +160,8 @@ describe ResponseMate::Manifest do
     end
 
     context 'when no key is missing' do
-      let(:keys) { %w[key1 key2] }
-      let(:existing_requests) { (keys + ['spare_key']).map { |key| double(key: key) } }
+      let(:keys) { %w[key1] }
+      let(:existing_requests) { keys.map { |key| double(key: key) } }
 
       before do
         allow(manifest).to receive(:requests).and_return(existing_requests)


### PR DESCRIPTION
Array#select! returns something only if a mutation happened,
else it returns nil.

Now, #requests_for_keys always returns the remaining keys.
